### PR TITLE
Fix URLs used by the generated documentation site

### DIFF
--- a/CommsRadioDocsSite/settings.yaml
+++ b/CommsRadioDocsSite/settings.yaml
@@ -1,2 +1,4 @@
+# Preview locally with: dotnet run --project CommsRadioDocsSite/CommsRadioDocsSite.csproj -- preview --virtual-dir /dv-comms-radio-api
+LinkRoot: /dv-comms-radio-api
 SourceFiles:
   - ../../CommsRadioAPI/**/{!.git,!bin,!obj,!packages,!*.Tests,}/**/*.cs

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ class CounterBehaviour : AStateBehaviour
 >
 > `OnAction` is not allowed to do this. Set the state's button behaviour to `ButtonBehaviourType.Ignore` instead.
 
-### Full API
+### Full API Documentation
 
-View the entire API at https://fauxnik.github.io/dv-comms-radio-api.
+View the [full API documentation](https://fauxnik.github.io/dv-comms-radio-api/api/CommsRadioAPI).
 
 
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ CommsRadioMode mode = CommsRadioMode.Create(MyInitialStateBehaviour, laserColor:
 To specify the ordering of the Comms Radio mode, pass an `insertBefore` predicate.
 
 ```csharp
-CommsRadioMode mode = CommsRadioMode.Create(MyInitialStateBehaviour, insertBefore: crm => crm == ControllerAPI.GetVanillaMode(VanillaMode.LED));
+CommsRadioMode mode = CommsRadioMode.Create(MyInitialStateBehaviour, insertBefore: mode => mode == ControllerAPI.GetVanillaMode(VanillaMode.LED));
 ```
 
 > [!IMPORTANT] 


### PR DESCRIPTION
The generated documentation site wasn't working because the URLs were pointing to the wrong place. They were missing the repository name that follows the domain name for project site hosted GitHub pages.

WRONG: `https://fauxnik.github.io/api/CommsRadioAPI`

CORRECT: `https://fauxnik.github.io/dv-comms-radio-api/api/CommsRadioAPI`