### PR TITLE
Make compatible with Build 98

### DIFF
--- a/CommsRadioAPI/CommsRadioAPI.csproj
+++ b/CommsRadioAPI/CommsRadioAPI.csproj
@@ -18,6 +18,7 @@
 		<Reference Include="UnityEngine"/>
 		<Reference Include="UnityEngine.AudioModule"/>
 		<Reference Include="UnityEngine.CoreModule"/>
+		<Reference Include="Unity.TextMeshPro"/>
 	</ItemGroup>
 
 	<!-- Mod Loader -->


### PR DESCRIPTION
Fixes missing method errors caused by Build 98.