### PR TITLE
Correct Repository link in info.json

### DIFF
--- a/info.json
+++ b/info.json
@@ -5,5 +5,5 @@
 	"Author": "Niko Fox",
 	"EntryMethod": "CommsRadioAPI.Main.Load",
 	"ManagerVersion": "0.27.3",
-	"Repository": "https://raw.githubusercontent.com/fauxnik/dv-comms-radio-api/blob/main/repository.json"
+	"Repository": "https://raw.githubusercontent.com/fauxnik/dv-comms-radio-api/main/repository.json"
 }


### PR DESCRIPTION
I noticed that auto-update did not happen for this mod due to an incorrect repository link.  This pull request fixes this.